### PR TITLE
Added paru to pacman wrappers

### DIFF
--- a/src/pacman-wrappers.md
+++ b/src/pacman-wrappers.md
@@ -3,6 +3,7 @@
 - [Aura](https://github.com/fosskers/aura) (Haskell) - A secure, multilingual package manager for Arch Linux and the AUR.
 - [Pacaur](https://github.com/E5ten/pacaur) (Bash) - An AUR helper that minimizes user interaction.
 - [Pakku](https://github.com/kitsunyan/pakku) (Nim) - `pacman` wrapper with AUR support.
+- [Paru](https://github.com/Morganamilo/paru) (Rust) - AUR helper with all needed modern wrapper features, created by a former developer of yay.
 - [pikaur](https://github.com/actionless/pikaur) (Python) - AUR helper with minimal dependencies. Review PKGBUILDs all in once, next build them all without user interaction.
 - [Trizen](https://github.com/trizen/trizen) (Perl) - Lightweight AUR Package Manager.
 - [Yay](https://github.com/Jguer/yay) (Go) - Yet another Yogurt, an AUR Helper written in Go.


### PR DESCRIPTION
I was just scrolling through Arch related topics and haven't seen it on the list.

I am long-time satisfied with `paru`, so it feels safe to recommend it to everybody else.