### PR TITLE
Update anarchy installer url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ It has everything on board to build AOSP or AOSP-based distributions like Lineag
 
 > Installers created specifically to facilitate the installation of Linux Arch.
 
-- [Anarchy](https://anarchyinstaller.org/) - A simple and intuitive Arch Linux installer.
+- [Anarchy](https://anarchyinstaller.gitlab.io) - A simple and intuitive Arch Linux installer.
 - [Archfi](https://github.com/MatMoul/archfi) - Just a simple bash script wizard to install Arch Linux after you have booted on the official Arch Linux install media.
 
 ## AUR Helpers

--- a/src/arch-linux-installers.md
+++ b/src/arch-linux-installers.md
@@ -2,5 +2,5 @@
 
 > Installers created specifically to facilitate the installation of Linux Arch.
 
-- [Anarchy](https://anarchyinstaller.org/) - A simple and intuitive Arch Linux installer.
+- [Anarchy](https://anarchyinstaller.gitlab.io/) - A simple and intuitive Arch Linux installer.
 - [Archfi](https://github.com/MatMoul/archfi) - Just a simple bash script wizard to install Arch Linux after you have booted on the official Arch Linux install media.


### PR DESCRIPTION
On the anarchy installer website they say this:

"Important: As of April 16, 2021 the Anarchy Installer website will be accessible exclusively from https://anarchyinstaller.gitlab.io."

So I opened this pull request to update the url.