### PR TITLE
Remove Manjaro due to numerous security issues

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,6 @@
 
 > Linux distributions based on Arch Linux for general use.
 
-- [Manjaro](https://manjaro.org/) - A professionally made Linux based operating system that is a suitable replacement for Windows or macOS.
 - [ArcoLinux](https://arcolinux.com/) - A full-featured distribution.
 - [ArchBang Linux](http://archbang.org/) - A lightweight distribution based on Arch Linux.
 - [Archcraft OS](https://archcraft-os.github.io/) - A Minimalistic Linux Distribution, Focused On Aesthetics & Based On Arch Linux.

--- a/src/desktop.md
+++ b/src/desktop.md
@@ -2,7 +2,6 @@
 
 > Linux distributions based on Arch Linux for general use.
 
-- [Manjaro](https://manjaro.org/) - A professionally made Linux based operating system that is a suitable replacement for Windows or macOS.
 - [ArcoLinux](https://arcolinux.com/) - A full-featured distribution.
 - [ArchBang Linux](http://archbang.org/) - A lightweight distribution based on Arch Linux.
 - [Archcraft OS](https://archcraft-os.github.io/) - A Minimalistic Linux Distribution, Focused On Aesthetics & Based On Arch Linux.


### PR DESCRIPTION
Manjaro is a Linux distro that has been flawed by numerous security issues over the years. 

For example, they [didn't upgrade their SSL certs and then told users to change their clock](https://www.reddit.com/r/linux/comments/31yayt/manjaro_forgot_to_upgrade_their_ssl_certificate/), [had an inexcusable PrivEsc bug in manjaro-system for seven years](https://lists.manjaro.org/pipermail/manjaro-security/2018-August/000785.html) and [almost had passwordless installs in their AUR helper](https://gitlab.manjaro.org/applications/pamac/-/issues/719).

To top it off, it's more unstable than Arch. 
They only hold back Arch repos, not the AUR, which could mean AUR package X depends on library Y version 11.1, which isn't in Manjaro's repositories yet. This could mean AUR packages randomly stop working (especially if it's something widely used like GTK or libcurl).

All in all, this distro is dubiable at best and shouldn't be on this list.