### PR TITLE
Draft: Add JuNest project to other-projects

### DIFF
--- a/book/other-projects.html
+++ b/book/other-projects.html
@@ -168,7 +168,7 @@
 <li><a href="https://termuxarch.github.io/TermuxArch/">Termux Arch</a> - Run Arch Linux ARM on your mobile phone with Termux.</li>
 <li><a href="https://hub.docker.com/r/archlinux/base/">archlinux/base</a> - A docker image based on Arch Linux.</li>
 <li><a href="https://www.uplinklabs.net/projects/arch-linux-on-ec2/">Arch Linux on EC2</a> - Amazon EC2 AMIs based on Arch Linux</li>
-<li><a href="https://github.com/fsquillace/junest">Arch-based "container" which can run on top of any Linux distribution</li>
+<li><a href="https://github.com/fsquillace/junest">A lightweight Arch Linux-based distro that runs, without root privileges, upon any Linux distro</li>
 </ul>
 
                     </main>

--- a/book/other-projects.html
+++ b/book/other-projects.html
@@ -168,6 +168,7 @@
 <li><a href="https://termuxarch.github.io/TermuxArch/">Termux Arch</a> - Run Arch Linux ARM on your mobile phone with Termux.</li>
 <li><a href="https://hub.docker.com/r/archlinux/base/">archlinux/base</a> - A docker image based on Arch Linux.</li>
 <li><a href="https://www.uplinklabs.net/projects/arch-linux-on-ec2/">Arch Linux on EC2</a> - Amazon EC2 AMIs based on Arch Linux</li>
+<li><a href="https://github.com/fsquillace/junest">Arch-based "container" which can run on top of any Linux distribution</li>
 </ul>
 
                     </main>

--- a/readme.md
+++ b/readme.md
@@ -170,6 +170,7 @@ It has everything on board to build AOSP or AOSP-based distributions like Lineag
 - [Termux Arch](https://termuxarch.github.io/TermuxArch/) - Run Arch Linux ARM on your mobile phone with Termux.
 - [archlinux/base](https://hub.docker.com/r/archlinux/base/) - A docker image based on Arch Linux.
 - [Arch Linux on EC2](https://www.uplinklabs.net/projects/arch-linux-on-ec2/) - Amazon EC2 AMIs based on Arch Linux
+- [JuNest](https://github.com/fsquillace/junest) - Arch-based "container" which can run on top of any Linux distribution
 
 ## Contribute
 

--- a/readme.md
+++ b/readme.md
@@ -170,7 +170,7 @@ It has everything on board to build AOSP or AOSP-based distributions like Lineag
 - [Termux Arch](https://termuxarch.github.io/TermuxArch/) - Run Arch Linux ARM on your mobile phone with Termux.
 - [archlinux/base](https://hub.docker.com/r/archlinux/base/) - A docker image based on Arch Linux.
 - [Arch Linux on EC2](https://www.uplinklabs.net/projects/arch-linux-on-ec2/) - Amazon EC2 AMIs based on Arch Linux
-- [JuNest](https://github.com/fsquillace/junest) - Arch-based "container" which can run on top of any Linux distribution
+- [JuNest](https://github.com/fsquillace/junest) - A lightweight Arch Linux-based distro that runs, without root privileges, upon any Linux distro.
 
 ## Contribute
 

--- a/src/other-projects.md
+++ b/src/other-projects.md
@@ -5,3 +5,4 @@
 - [Termux Arch](https://termuxarch.github.io/TermuxArch/) - Run Arch Linux ARM on your mobile phone with Termux.
 - [archlinux/base](https://hub.docker.com/r/archlinux/base/) - A docker image based on Arch Linux.
 - [Arch Linux on EC2](https://www.uplinklabs.net/projects/arch-linux-on-ec2/) - Amazon EC2 AMIs based on Arch Linux
+- [JuNest](https://github.com/fsquillace/junest) - Arch-based "container" which can run on top of any Linux distribution

--- a/src/other-projects.md
+++ b/src/other-projects.md
@@ -5,4 +5,4 @@
 - [Termux Arch](https://termuxarch.github.io/TermuxArch/) - Run Arch Linux ARM on your mobile phone with Termux.
 - [archlinux/base](https://hub.docker.com/r/archlinux/base/) - A docker image based on Arch Linux.
 - [Arch Linux on EC2](https://www.uplinklabs.net/projects/arch-linux-on-ec2/) - Amazon EC2 AMIs based on Arch Linux
-- [JuNest](https://github.com/fsquillace/junest) - Arch-based "container" which can run on top of any Linux distribution
+- [JuNest](https://github.com/fsquillace/junest) - A lightweight Arch Linux-based distro that runs, without root privileges, upon any Linux distro.


### PR DESCRIPTION
[JuNest](https://github.com/fsquillace/junest) is a really Awesome project based on Arch, I think it should be on the list!
I'm not part of the project, so maybe the author @fsquillace wants to change the description:

- [JuNest](https://github.com/fsquillace/junest) - Arch-based "container" which can run on top of any Linux distribution