### PR TITLE
Added 'tarman' to 'other projects'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,7 @@ It has everything on board to build AOSP or AOSP-based distributions like Lineag
 - [Arch Linux on EC2](https://www.uplinklabs.net/projects/arch-linux-on-ec2/) - Amazon EC2 AMIs based on Arch Linux
 - [JuNest](https://github.com/fsquillace/junest) - A lightweight Arch Linux-based distro that runs, without root privileges, upon any Linux distro.
 - [makepkg-optimize](https://github.com/ptr1337/makepkg-optimize) - A collection of supplemental tidy, buildenv, and executable scripts for pacman which provide macros for several kinds of optimization in the build() and package() stages.
+- [tarman](https://github.com/Alessandro-Salerno/tarman) -  The portable, cross-platform, extensible, and simple package manager for tarballs (and others!) 
 
 ## Inactive projects
 

--- a/src/other-projects.md
+++ b/src/other-projects.md
@@ -6,3 +6,4 @@
 - [archlinux/base](https://hub.docker.com/r/archlinux/base/) - A docker image based on Arch Linux.
 - [Arch Linux on EC2](https://www.uplinklabs.net/projects/arch-linux-on-ec2/) - Amazon EC2 AMIs based on Arch Linux
 - [JuNest](https://github.com/fsquillace/junest) - A lightweight Arch Linux-based distro that runs, without root privileges, upon any Linux distro.
+- [tarman](https://github.com/Alessandro-Salerno/tarman) -  The portable, cross-platform, extensible, and simple package manager for tarballs (and others!) 

--- a/src/other-projects.md
+++ b/src/other-projects.md
@@ -6,4 +6,5 @@
 - [archlinux/base](https://hub.docker.com/r/archlinux/base/) - A docker image based on Arch Linux.
 - [Arch Linux on EC2](https://www.uplinklabs.net/projects/arch-linux-on-ec2/) - Amazon EC2 AMIs based on Arch Linux
 - [JuNest](https://github.com/fsquillace/junest) - A lightweight Arch Linux-based distro that runs, without root privileges, upon any Linux distro.
+- [makepkg-optimize](https://github.com/ptr1337/makepkg-optimize) - A collection of supplemental tidy, buildenv, and executable scripts for pacman which provide macros for several kinds of optimization in the build() and package() stages.
 - [tarman](https://github.com/Alessandro-Salerno/tarman) -  The portable, cross-platform, extensible, and simple package manager for tarballs (and others!) 


### PR DESCRIPTION
Hi,
I've recently been working on a package manager for tar.gz archives, I use it myself now and I think someone else could benefit from it. It's technically portable to any OS, but I made it primarily for my own use case on EndeavourOS (Arch), so I figured this was probably the most appropriate repository to add it to.

I also noticed that another project had only been added to the `README`, but not to the `src/other-projects.md` file, so I added it alongside mine.

I hope these changes fit all your guidelines and can be useful/helpful for others.

Best regards